### PR TITLE
Accept latest array, slightly older containers

### DIFF
--- a/palette.cabal
+++ b/palette.cabal
@@ -21,8 +21,8 @@ Library
                        Data.Colour.Palette.BrewerSet
 
   Build-depends:       base >= 4.2 && < 4.8,
-                       array >= 0.4 && < 0.5,
+                       array >= 0.4 && < 0.6,
                        colour >= 2.3 && <3.0,
-                       containers >= 0.5.3.0 && < 0.6.0.0
+                       containers >= 0.5 && < 0.6.0.0
 
   hs-source-dirs:      src


### PR DESCRIPTION
These make palette a little easier to build alongside other packages.  It builds fine for me, and diagrams-doc `Shake buildh` runs without error.
