### PR TITLE
Fix link in BrewerSet module haddock

### DIFF
--- a/src/Data/Colour/Palette/BrewerSet.hs
+++ b/src/Data/Colour/Palette/BrewerSet.hs
@@ -7,7 +7,7 @@
 --
 -- Sets of between 3 and 12 colors.
 -- This product includes color specifications and designs developed by
--- Cynthia Brewer (http://colorbrewer.org/).
+-- <http://colorbrewer.org/ Cynthia Brewer>.
 --
 -----------------------------------------------------------------------------
 


### PR DESCRIPTION
The slashes in the URL are currently getting rendered as italics.

Sorry about the extraneous trailing newline diff. GitHub's pull request UI did that.