### PR TITLE
Update dependencies to build with ghc 8.6, more recent stackage lts

### DIFF
--- a/palette.cabal
+++ b/palette.cabal
@@ -1,5 +1,5 @@
 Name:                palette
-Version:             0.3.0.1
+Version:             0.3.0.2
 Synopsis:            Utilities for choosing and creating color schemes.
 Description:         Sets of predefined colors and tools for choosing and
                      creating color schemes. Random colors.

--- a/palette.cabal
+++ b/palette.cabal
@@ -28,9 +28,9 @@ Library
                        Data.Colour.Palette.Types
                        Data.Colour.Palette.RandomColor
 
-  Build-depends:       base >= 4.2 && < 4.12,
+  Build-depends:       base >= 4.2 && < 4.13,
                        array >= 0.4 && < 0.6,
                        colour >= 2.3 && <3.0,
-                       containers >= 0.5 && < 0.6,
+                       containers >= 0.5 && < 0.7,
                        MonadRandom >= 0.5 && < 0.6
   hs-source-dirs:      src

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-11.8
+resolver: lts-13.8
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Bump versions to get this package to build with ghc version 8.6 and more recent stackage lts. This also increases the version to 0.3.0.2